### PR TITLE
Set the prefix for building with make

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,5 +22,5 @@ then
     export USECLANG=0
 fi
 
-make
+make prefix="${PREFIX}/"
 make install prefix="${PREFIX}/"


### PR DESCRIPTION
Not really necessary currently, but it is nice to set the build prefix so that any includes or libraries are picked up from our build prefix and not somewhere else on the system. As openlibm doesn't really have any build requirements currently, this doesn't affect anything. However it still nice to have this set correctly here if that should change in the future. Also makes for a better template when adding other recipes configured this way.